### PR TITLE
A small change so that it compiles on go version go1.5.3 linux/amd64

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -166,7 +166,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	var cipher *cookie.Cipher
 	if opts.PassAccessToken || (opts.CookieRefresh != time.Duration(0)) {
 		var err error
-		cipher, err = cookie.NewCipher(opts.CookieSecret)
+		cipher, err = cookie.NewCipher([]byte(opts.CookieSecret))
 		if err != nil {
 			log.Fatal("error creating AES cipher with "+
 				"cookie-secret ", opts.CookieSecret, ": ", err)


### PR DESCRIPTION
Hi,

This my first Go code written. While trying to compile the project on an Amazon instance, it would fail with `./oauthproxy.go:169: cannot use opts.CookieSecret (type string) as type []byte in argument to cookie.NewCipher`

This is the solution I found that allows compiling on `go1.5.3 linux/amd64`.

Best regards,
Cosmin